### PR TITLE
add suport to multi pools report

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,11 @@ A FastAPI-based web service that generates and emails performance reports for Ba
 ## Features
 
 - 📊 **Works with Both V2 and V3 Pools** - Automatically detects pool version
+- 🔀 **Multi-Pool Comparison** - Compare multiple pools with rankings and totals
 - 📈 Compares current metrics with 15-day historical data
 - 📧 Sends beautifully styled HTML email reports matching balancer.fi design
+- 🏆 Rankings: Top 3 pools by Volume and TVL
+- 💰 Aggregated metrics: Total fees and weighted average APR
 - 🚀 FastAPI with automatic API documentation
 - ⚡ Async/await for efficient API calls
 - 🔒 Type-safe with Pydantic models
@@ -70,8 +73,14 @@ FROM_EMAIL=your_email@gmail.com
 # Balancer APIs
 BALANCER_V3_API=https://api-v3.balancer.fi/graphql
 BALANCER_V2_SUBGRAPH=https://api.thegraph.com/subgraphs/name/balancer-labs/balancer-v2
-DEFAULT_CHAIN=MAINNET
+DEFAULT_CHAIN=MAINNET          # For API queries (MAINNET, ARBITRUM, POLYGON, etc.)
+BLOCKCHAIN_NAME=ethereum       # For balancer.fi URLs (ethereum, arbitrum, polygon, etc.)
 ```
+
+**Multi-Chain Support:**
+- `DEFAULT_CHAIN`: Used for GraphQL API queries (e.g., `MAINNET`, `ARBITRUM`, `POLYGON`)
+- `BLOCKCHAIN_NAME`: Used for generating balancer.fi URLs (e.g., `ethereum`, `arbitrum`, `polygon`)
+- Both should represent the same network, just in different formats
 
 ### Gmail SMTP Setup
 
@@ -97,20 +106,45 @@ FastAPI provides automatic interactive documentation:
 - **Swagger UI**: http://localhost:8000/docs
 - **ReDoc**: http://localhost:8000/redoc
 
-### Generate a Report
+### Generate a Single Pool Report
 
-Send a POST request to `/report`:
+Send a POST request to `/report` with one pool:
 
 ```bash
 curl -X POST "http://localhost:8000/report" \
   -H "Content-Type: application/json" \
   -d '{
-    "pool_address": "0x3de27efa2f1aa663ae5d458857e731c129069f29",
+    "pool_addresses": ["0x3de27efa2f1aa663ae5d458857e731c129069f29"],
     "recipient_email": "your.email@example.com"
   }'
 ```
 
+### Generate a Multi-Pool Comparison Report
+
+Send a POST request with multiple pools:
+
+```bash
+curl -X POST "http://localhost:8000/report" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "pool_addresses": [
+      "0x3de27efa2f1aa663ae5d458857e731c129069f29",
+      "0x5c6ee304399dbdb9c8ef030ab642b10820db8f56",
+      "0x96646936b91d6b9d7d0c47c496afbf3d6ec7b6f8"
+    ],
+    "recipient_email": "your.email@example.com"
+  }'
+```
+
+**Multi-Pool Report Includes:**
+- 🏆 Top 3 pools by Trading Volume (with % of total portfolio volume)
+- 💎 Top 3 pools by TVL Growth (absolute increase + % change from 15 days ago)
+- 💰 Total Fees collected (all pools combined)
+- 🚀 Weighted Average APR (by TVL)
+
 Or use the interactive Swagger UI at `/docs` to test the endpoint.
+
+**Note:** For backwards compatibility, you can still use `pool_address` (singular) for single pool reports.
 
 ### Health Check
 
@@ -122,12 +156,23 @@ curl http://localhost:8000/health
 
 ### POST /report
 
-Generate and send a pool performance report via email.
+Generate and send a pool performance report via email (single or multiple pools).
 
-**Request Body:**
+**Request Body (Single Pool):**
 ```json
 {
-  "pool_address": "0x3de27efa2f1aa663ae5d458857e731c129069f29",
+  "pool_addresses": ["0x3de27efa2f1aa663ae5d458857e731c129069f29"],
+  "recipient_email": "user@example.com"
+}
+```
+
+**Request Body (Multiple Pools):**
+```json
+{
+  "pool_addresses": [
+    "0x3de27efa2f1aa663ae5d458857e731c129069f29",
+    "0x5c6ee304399dbdb9c8ef030ab642b10820db8f56"
+  ],
   "recipient_email": "user@example.com"
 }
 ```

--- a/config.py
+++ b/config.py
@@ -21,7 +21,8 @@ class Settings(BaseSettings):
     balancer_v2_subgraph: str = "https://api.studio.thegraph.com/query/24660/balancer-ethereum-v2/version/latest"
     # Optional: Unified Balancer GraphQL endpoint (if you have one)
     balancer_gql_endpoint: str | None = None
-    default_chain: str = "MAINNET"
+    default_chain: str = "MAINNET"  # For API queries (e.g., MAINNET, ARBITRUM, POLYGON)
+    blockchain_name: str = "ethereum"  # For balancer.fi URLs (e.g., ethereum, arbitrum, polygon)
     
     # Optional default pool
     default_pool_address: str | None = None

--- a/services/balancer_api.py
+++ b/services/balancer_api.py
@@ -21,7 +21,8 @@ class BalancerAPI:
         self.gql_endpoint = settings.balancer_gql_endpoint
         self.v3_api_url = settings.balancer_v3_api
         self.v2_subgraph_url = self.gql_endpoint or settings.balancer_v2_subgraph
-        self.chain = settings.default_chain
+        self.chain = settings.default_chain  # For API queries (e.g., MAINNET)
+        self.blockchain_name = settings.blockchain_name  # For balancer.fi URLs (e.g., ethereum)
         
         if self.gql_endpoint:
             print(f"🔗 Using Balancer GQL Endpoint: {self.gql_endpoint}")
@@ -130,6 +131,9 @@ class BalancerAPI:
             
             if pool:
                 print(f"✅ Found V3 pool: {pool.get('name')}")
+                # Add metadata for URL generation
+                pool['_api_version'] = 'v3'
+                pool['_blockchain'] = self.blockchain_name
                 return pool
         except Exception as e:
             print(f"⚠️  V3 API failed: {str(e)}")
@@ -192,6 +196,8 @@ class BalancerAPI:
             "name": v2_pool.get("name") or f"Pool {v2_pool.get('poolType', 'Unknown')}",
             "type": v2_pool.get("poolType", "Unknown"),
             "version": 2,
+            "_api_version": "v2",  # Add metadata for URL generation
+            "_blockchain": self.blockchain_name,  # Blockchain name for balancer.fi URLs
             "dynamicData": {
                 "totalLiquidity": v2_pool.get("totalLiquidity", "0"),
                 "volume24h": "0",  # Not available in single query

--- a/templates/email_report.html
+++ b/templates/email_report.html
@@ -40,7 +40,7 @@
                     <tr>
                         <td style="padding: 32px 36px; background-color: #31363F; border-bottom: 1px solid #5B6068;">
                             <h2 style="margin: 0 0 16px; color: #E5D1B9; font-size: 24px; font-weight: 700;">
-                                {{ pool_name }}
+                                <a href="{{ pool_url }}" style="color: #E5D1B9; text-decoration: none;">{{ pool_name }} 🔗</a>
                             </h2>
                             
                             <!-- Token Pills Row -->

--- a/templates/email_report_multi.html
+++ b/templates/email_report_multi.html
@@ -1,0 +1,169 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Balancer Pools Comparison Report</title>
+</head>
+<body style="margin: 0; padding: 0; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Helvetica Neue', Arial, sans-serif; background-color: #31363F;">
+    <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%" style="background-color: #31363F;">
+        <tr>
+            <td style="padding: 40px 20px;">
+                <!-- Main Container -->
+                <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%" style="max-width: 650px; margin: 0 auto; background-color: #31363F; border-radius: 16px; box-shadow: 0 8px 32px rgba(0, 0, 0, 0.5); border: 1px solid #5B6068;">
+                    
+                    <!-- Header with purple to yellow gradient -->
+                    <tr>
+                        <td style="padding: 40px 36px 32px; background: linear-gradient(135deg, #BAB3F3 0%, #D4CAD8 50%, #E5D1B9 100%); border-radius: 16px 16px 0 0;">
+                            <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%">
+                                <tr>
+                                    <!-- Title on left -->
+                                    <td style="vertical-align: middle; width: 70%;">
+                                        <h1 style="margin: 0 0 12px; color: #31363F; font-size: 32px; font-weight: 700; letter-spacing: -0.8px; line-height: 1.2;">
+                                            Pools Comparison
+                                        </h1>
+                                        <p style="margin: 0; color: #31363F; font-size: 16px; font-weight: 600; opacity: 0.8;">
+                                            📊 {{ pool_count }} Pools • 15-Day Analysis
+                                        </p>
+                                    </td>
+                                    <!-- Logo on right -->
+                                    <td style="vertical-align: middle; text-align: right; width: 30%;">
+                                        <img src="https://cryptologos.cc/logos/balancer-bal-logo.png" alt="Balancer" width="70" height="70" style="display: block; margin-left: auto;" />
+                                    </td>
+                                </tr>
+                            </table>
+                        </td>
+                    </tr>
+                    
+                    <!-- Top 3 by Volume -->
+                    <tr>
+                        <td style="padding: 32px 36px 24px; background-color: #31363F;">
+                            <h2 style="margin: 0 0 20px; color: #E5D1B9; font-size: 20px; font-weight: 700; text-transform: uppercase; letter-spacing: 1px;">
+                                🏆 Top 3 by Trading Volume
+                            </h2>
+                            
+                            {% for pool in top_3_volume %}
+                            <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%" style="margin-bottom: 12px;">
+                                <tr>
+                                    <td style="padding: 16px 20px; background-color: #5B6068; border-radius: 8px; border-left: 4px solid {% if pool.rank == 1 %}#E5D1B9{% elif pool.rank == 2 %}#BAB3F3{% else %}#8B8EA7{% endif %};">
+                                        <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%">
+                                            <tr>
+                                                <td style="vertical-align: middle; width: 50%;">
+                                                    <span style="color: #E5D1B9; font-size: 24px; font-weight: 800; margin-right: 12px;">{{ pool.rank }}</span>
+                                                    <a href="{{ pool.url }}" style="color: #E5D1B9; font-size: 16px; font-weight: 600; text-decoration: none;">{{ pool.name }} 🔗</a>
+                                                </td>
+                                                <td style="vertical-align: middle; text-align: right; width: 50%;">
+                                                    <div>
+                                                        <span style="color: #BAB3F3; font-size: 18px; font-weight: 700; display: block;">{{ pool.value }}</span>
+                                                        <span style="color: #8B8EA7; font-size: 13px; font-weight: 600; display: block; margin-top: 4px;">{{ pool.percentage }} of total</span>
+                                                    </div>
+                                                </td>
+                                            </tr>
+                                        </table>
+                                    </td>
+                                </tr>
+                            </table>
+                            {% endfor %}
+                        </td>
+                    </tr>
+                    
+                    <!-- Top 3 by TVL Increase -->
+                    <tr>
+                        <td style="padding: 0 36px 24px; background-color: #31363F;">
+                            <h2 style="margin: 0 0 20px; color: #E5D1B9; font-size: 20px; font-weight: 700; text-transform: uppercase; letter-spacing: 1px;">
+                                💎 Top 3 by TVL Growth
+                            </h2>
+                            
+                            {% for pool in top_3_tvl %}
+                            <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%" style="margin-bottom: 12px;">
+                                <tr>
+                                    <td style="padding: 16px 20px; background-color: #5B6068; border-radius: 8px; border-left: 4px solid {% if pool.rank == 1 %}#E5D1B9{% elif pool.rank == 2 %}#BAB3F3{% else %}#8B8EA7{% endif %};">
+                                        <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%">
+                                            <tr>
+                                                <td style="vertical-align: middle; width: 50%;">
+                                                    <span style="color: #E5D1B9; font-size: 24px; font-weight: 800; margin-right: 12px;">{{ pool.rank }}</span>
+                                                    <a href="{{ pool.url }}" style="color: #E5D1B9; font-size: 16px; font-weight: 600; text-decoration: none;">{{ pool.name }} 🔗</a>
+                                                </td>
+                                                <td style="vertical-align: middle; text-align: right; width: 50%;">
+                                                    <div>
+                                                        <span style="color: #BAB3F3; font-size: 18px; font-weight: 700; display: block;">{{ pool.value }}</span>
+                                                        <span style="color: {% if pool.percentage.startswith('+') %}#90EE90{% else %}#FF6B6B{% endif %}; font-size: 14px; font-weight: 700; display: block; margin-top: 4px;">{{ pool.percentage }}</span>
+                                                    </div>
+                                                </td>
+                                            </tr>
+                                        </table>
+                                    </td>
+                                </tr>
+                            </table>
+                            {% endfor %}
+                        </td>
+                    </tr>
+                    
+                    <!-- Total Metrics Grid -->
+                    <tr>
+                        <td style="padding: 0 36px 32px; background-color: #31363F;">
+                            <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%">
+                                <tr>
+                                    <!-- Total Fees -->
+                                    <td width="48%" style="padding: 24px; background-color: #5B6068; border-radius: 12px; border: 2px solid #BAB3F3; vertical-align: top;">
+                                        <p style="margin: 0 0 8px; color: #BAB3F3; font-size: 12px; text-transform: uppercase; letter-spacing: 1px; font-weight: 700;">
+                                            💰 TOTAL FEES
+                                        </p>
+                                        <h4 style="margin: 0; color: #E5D1B9; font-size: 28px; font-weight: 800;">
+                                            {{ total_fees }}
+                                        </h4>
+                                        <p style="margin: 6px 0 0; color: #BAB3F3; font-size: 11px; opacity: 0.7;">
+                                            Combined (15 Days)
+                                        </p>
+                                    </td>
+                                    <td width="4%"></td>
+                                    <!-- Average APR -->
+                                    <td width="48%" style="padding: 24px; background: linear-gradient(135deg, #E5D1B9 0%, #D4C8A8 100%); border-radius: 12px; border: 2px solid #E5D1B9; vertical-align: top;">
+                                        <p style="margin: 0 0 8px; color: #31363F; font-size: 12px; text-transform: uppercase; letter-spacing: 1px; font-weight: 700;">
+                                            🚀 WEIGHTED AVG APR
+                                        </p>
+                                        <h4 style="margin: 0; color: #31363F; font-size: 28px; font-weight: 800;">
+                                            {{ total_apr }}
+                                        </h4>
+                                        <p style="margin: 6px 0 0; color: #31363F; font-size: 11px; opacity: 0.7;">
+                                            By TVL
+                                        </p>
+                                    </td>
+                                </tr>
+                            </table>
+                        </td>
+                    </tr>
+                    
+                    <!-- Footer -->
+                    <tr>
+                        <td style="padding: 28px 36px; background-color: #5B6068; border-radius: 0 0 16px 16px; border-top: 2px solid #BAB3F3;">
+                            <p style="margin: 0 0 8px; color: #E5D1B9; font-size: 13px; font-weight: 600;">
+                                <strong style="color: #E5D1B9;">📅 Report Generated:</strong> {{ timestamp }}
+                            </p>
+                            <p style="margin: 0; color: #BAB3F3; font-size: 12px; opacity: 0.8;">
+                                Multi-pool comparison powered by Balancer Pool Reporter
+                            </p>
+                            <p style="margin: 12px 0 0; color: #BAB3F3; font-size: 11px; opacity: 0.6;">
+                                ⚡ Data sourced from Balancer V2/V3 GraphQL APIs
+                            </p>
+                        </td>
+                    </tr>
+                    
+                </table>
+                
+                <!-- Balancer Footer -->
+                <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%" style="max-width: 650px; margin: 24px auto 0;">
+                    <tr>
+                        <td style="text-align: center; padding: 0 20px;">
+                            <p style="margin: 0; color: #BAB3F3; font-size: 12px; font-weight: 600; letter-spacing: 0.5px; opacity: 0.6;">
+                                POWERED BY BALANCER PROTOCOL
+                            </p>
+                        </td>
+                    </tr>
+                </table>
+                
+            </td>
+        </tr>
+    </table>
+</body>
+</html>


### PR DESCRIPTION
# Multi-Pool Comparison Report

## Summary
Added support for comparing multiple Balancer pools in a single email report with rankings and aggregated metrics.

## Features
- 🏆 **Top 3 by Volume** - Shows volume + % of total
- 💎 **Top 3 by TVL Growth** - Absolute increase + % change (15 days)
- 💰 **Total Fees** - Combined across all pools
- 🚀 **Weighted Avg APR** - TVL-weighted
- 🔗 **Clickable Pool Links** - Direct links to balancer.fi

## Usage

**Single Pool:**
```json
{
  "pool_addresses": ["0x3de27efa..."],
  "recipient_email": "user@example.com"
}
```

**Multiple Pools:**
```json
{
  "pool_addresses": ["0x3de27efa...", "0x5c6ee304...", "0x96646936..."],
  "recipient_email": "user@example.com"
}
```

## Technical
- New `MultiPoolMetrics` model
- New `email_report_multi.html` template
- Smart single/multi routing in `/report` endpoint
- URL generation for balancer.fi links
- Multi-chain support via `BLOCKCHAIN_NAME` config

## Design
Maintains Balancer color scheme with gradient header and ranking badges.
